### PR TITLE
Rename HA module to ha_terraform for improved clarity and consistency

### DIFF
--- a/modules/high_availability_existing_vnet/locals.tf
+++ b/modules/high_availability_existing_vnet/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  module_name = "high_availability"
+  module_name = "ha_terraform"
   module_version = "1.0.5"
 }

--- a/modules/high_availability_new_vnet/locals.tf
+++ b/modules/high_availability_new_vnet/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  module_name = "high_availability_terraform_registry"
+  module_name = "ha_terraform"
   module_version = "1.0.5"
 }


### PR DESCRIPTION
Rename HA module to ha_terraform for improved clarity and consistency