### PR TITLE
Fix: Remove the need for client_id and client_secret (issue #59)

### DIFF
--- a/modules/high-availability/variables.tf
+++ b/modules/high-availability/variables.tf
@@ -12,12 +12,14 @@ variable "tenant_id" {
 variable "client_id" {
   description = "Application ID(Client ID)"
   type        = string
+  default     = null
 }
 
 variable "client_secret" {
   description = "A secret string that the application uses to prove its identity when requesting a token. Also can be referred to as application password."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "resource_group_name" {

--- a/modules/high-availability/versions.tf
+++ b/modules/high-availability/versions.tf
@@ -16,15 +16,11 @@ terraform {
 }
 provider "azapi" {
   subscription_id = var.subscription_id
-  client_id       = var.client_id
-  client_secret   = var.client_secret
   tenant_id       = var.tenant_id
 }
 
 provider "azurerm" {
   subscription_id = var.subscription_id
-  client_id       = var.client_id
-  client_secret   = var.client_secret
   tenant_id       = var.tenant_id
   features {}
 }


### PR DESCRIPTION
Add default values for client_id and client_secret in the high-availability module and remove them from the provider blocks.